### PR TITLE
Adicionando Beans e criando o Swagger para documentar apis

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,13 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
+	//Swagger
+	implementation("io.springfox:springfox-swagger2:3.0.0")
+	implementation("io.springfox:springfox-swagger-ui:3.0.0")
+	implementation("io.springfox:springfox-boot-starter:3.0.0")
+
+
+
 	//flyaway
 	implementation("org.flywaydb:flyway-core:7.7.0")
 

--- a/src/main/kotlin/com/mercadolivro/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/mercadolivro/config/SwaggerConfig.kt
@@ -1,0 +1,29 @@
+package com.mercadolivro.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import springfox.documentation.builders.ApiInfoBuilder
+import springfox.documentation.builders.PathSelectors
+import springfox.documentation.builders.RequestHandlerSelectors
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spring.web.plugins.Docket
+import springfox.documentation.swagger2.annotations.EnableSwagger2
+
+@Configuration
+@EnableSwagger2
+class SwaggerConfig {
+
+    @Bean
+    fun api(): Docket = Docket(DocumentationType.SWAGGER_2)
+        .select()
+        .apis((RequestHandlerSelectors.basePackage("com.mercadolivro.controller")))
+        .paths(PathSelectors.any())
+        .build()
+
+        .apiInfo(ApiInfoBuilder()
+            .title("Mercado Livro")
+            .description("API do Mercado Livro")
+            .build()
+        )
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,6 @@ spring:
     password: root
   Jackson:
     default-property-inclusion: non_null
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher


### PR DESCRIPTION
Este PR, trata-se de adicionar o swagger no projeto, a fim de facilitar a documentação da API. 
Após rodar a aplicação será feita a construção da doc que poderá ser acessada por este link > localhost:8080/swagger-ui/